### PR TITLE
s3への接続成功メッセージをアップロードテスト成功後に変更

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -126,6 +126,7 @@ try {
   _s3Client = new Minio.Client(clientOption);
   _s3Client!.putObject(bucket, "sample-test.txt", "sample-text").then(() => {
     console.log("S3 Storage upload-test success.");
+    console.log(`S3 Storage connect success. (bucket: ${bucket})`);
   }).catch((err) => {
     console.error("S3 Storage upload-test failure.");
     console.error("Please review your settings. (src: config/storage.yaml)");
@@ -133,7 +134,7 @@ try {
     console.error(err);
     return;
   });
-  console.log(`S3 Storage connect success. (bucket: ${bucket})`);
+
 } catch (err) {
   console.error("S3 Storage connect failure. ");
   console.error("Please review your settings. (src: config/storage.yaml)");


### PR DESCRIPTION
開発お疲れ様です。

`S3 Storage connect success.`のメッセージが、storage.ymlでendPointの設定をミスしていて、
接続できない状態でも表示されていたので、
アップロードテストの成功後に表示することを提案いたします。

new Minio.Clientの挙動を確認しました。
・clientOptionのendPointがnullの場合、例外が発生しました。
・clientOptionのendPointが文字列なら、タイポしていて接続できなくなっていても、new の段階では例外は発生しませんでした。

現在の実装では、接続先が間違っている場合、putObjectの段階で例外が発生し、catchメソッドで例外処理されるため、upload-test失敗のメッセージと共に`S3 Storage connect success`が表示されているものと思われます。

